### PR TITLE
update ja-JP translation

### DIFF
--- a/locale/ja-JP/cipherfox.dtd
+++ b/locale/ja-JP/cipherfox.dtd
@@ -2,7 +2,7 @@
 <!ENTITY certs.tooltip    "証明書チェーンを表示します">
 <!ENTITY prefs.label      "設定">
 <!ENTITY prefs.accesskey  "P">
-<!ENTITY qualys.label     "Qualys SSL Labs サーバーのテスト">
+<!ENTITY qualys.label     "Qualys SSL Labs Server Test">
 <!ENTITY qualys.accesskey "Q">
-<!ENTITY copy.label       "Cipher Suite をクリップボードにコピー">
+<!ENTITY copy.label       "暗号スイートをクリップボードにコピー">
 <!ENTITY copy.accesskey   "C">

--- a/locale/ja-JP/prefs.dtd
+++ b/locale/ja-JP/prefs.dtd
@@ -8,7 +8,7 @@
 <!ENTITY formatting.label  "表示形式">
 <!ENTITY cipher.label      "暗号化">
 <!ENTITY cert.label        "証明書">
-<!ENTITY header.label      "メニュー見出し">
+<!ENTITY header.label      "ヘッダ">
 <!ENTITY default.label     "既定に戻す">
 <!ENTITY variables.label   "表示形式のパラメータ">
 <!ENTITY cipherAlg.label   "共通鍵のアルゴリズム">


### PR DESCRIPTION
1. I recognize "Qualys SSL Labs Server Test" is a proper noun, so I did not translate this entity intentionally.
2. Another "Cipher Suite" is translated into Japanese.
3. Better wording for "Menu Header". In Japanese, "Header" is enough.
